### PR TITLE
feat(ads): add Rakuten banners (PC 468x60 / SP 234x60 / how-to 380x60…

### DIFF
--- a/app/components/AdSlot.tsx
+++ b/app/components/AdSlot.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  html: string;
+  width: number;
+  height: number;
+  className?: string;
+  ariaLabel?: string;
+};
+
+export default function AdSlot({ html, width, height, className, ariaLabel = "広告" }: Props) {
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={className}
+      style={{ width, height, maxWidth: "100%" }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/app/constants/ads.ts
+++ b/app/constants/ads.ts
@@ -1,0 +1,6 @@
+// 楽天（もしも）バナーHTML
+export const RAKU_468x60 = `<a href="//af.moshimo.com/af/c/click?a_id=5102095&p_id=54&pc_id=54&pl_id=620" rel="nofollow" referrerpolicy="no-referrer-when-downgrade" attributionsrc><img src="//image.moshimo.com/af-img/0032/000000000620.gif" width="468" height="60" style="border:none;"></a><img src="//i.moshimo.com/af/i/impression?a_id=5102095&p_id=54&pc_id=54&pl_id=620" width="1" height="1" style="border:none;" loading="lazy">`;
+
+export const RAKU_234x60 = `<a href="//af.moshimo.com/af/c/click?a_id=5102095&p_id=54&pc_id=54&pl_id=619" rel="nofollow" referrerpolicy="no-referrer-when-downgrade" attributionsrc><img src="//image.moshimo.com/af-img/0032/000000000619.gif" width="234" height="60" style="border:none;"></a><img src="//i.moshimo.com/af/i/impression?a_id=5102095&p_id=54&pc_id=54&pl_id=619" width="1" height="1" style="border:none;" loading="lazy">`;
+
+export const RAKU_380x60 = `<a href="//af.moshimo.com/af/c/click?a_id=5102095&p_id=54&pc_id=54&pl_id=1227" rel="nofollow" referrerpolicy="no-referrer-when-downgrade" attributionsrc><img src="//image.moshimo.com/af-img/0032/000000001227.gif" width="380" height="60" style="border:none;"></a><img src="//i.moshimo.com/af/i/impression?a_id=5102095&p_id=54&pc_id=54&pl_id=1227" width="1" height="1" style="border:none;" loading="lazy">`;

--- a/app/how-to/page.tsx
+++ b/app/how-to/page.tsx
@@ -1,7 +1,14 @@
+import AdSlot from "@/app/components/AdSlot";
+import { RAKU_380x60 } from "@/app/constants/ads";
+import { ADS_ENABLED } from "@/lib/flags";
+
 export default function HowTo(){
   return (
     <div className="max-w-4xl mx-auto px-4 py-12 text-pretty ja-body">
       <h1 className="text-2xl font-bold text-balance mb-6">使い方</h1>
+      {ADS_ENABLED && (
+        <p className="text-xs text-slate-500 mb-4">※ 当サイトはアフィリエイト広告を利用しています。</p>
+      )}
       <ol className="list-decimal pl-5 space-y-2 leading-7">
         <li><a href="/app" className="text-sky-600 hover:underline">アプリ</a>を開く</li>
         <li>帳票タイプ（見積、発注、契約、請求、領収）を選ぶ</li>
@@ -14,6 +21,12 @@ export default function HowTo(){
         <li>URL共有は入力内容がURLに含まれます。機微情報の入力は控えてください。</li>
         <li>制度要件（適格請求書等）の最終確認はご自身でお願いします。</li>
       </ul>
+      
+      {ADS_ENABLED && (
+        <div className="mt-10 no-print">
+          <AdSlot html={RAKU_380x60} width={380} height={60} className="mx-auto" />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { CONTACT_EMAIL, CONTACT_MAILTO } from "./config/contact";
 import { IS_BETA } from "./config/site";
+import { ADS_ENABLED } from "@/lib/flags";
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://chouhyo.cocoroai.co.jp'),
@@ -103,6 +104,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {IS_BETA && (
               <div className="md:col-span-2 text-xs text-slate-500">
                 現在はベータ運用中です。仕様は予告なく変更となる場合があります。
+              </div>
+            )}
+            {ADS_ENABLED && (
+              <div className="md:col-span-2 text-xs text-slate-500">
+                当サイトはアフィリエイト広告を利用しています。
               </div>
             )}
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,7 @@
+import AdSlot from "@/app/components/AdSlot";
+import { RAKU_468x60, RAKU_234x60 } from "@/app/constants/ads";
+import { ADS_ENABLED } from "@/lib/flags";
+
 export const dynamic = 'force-static';
 
 
@@ -44,6 +48,25 @@ export default function LandingPage() {
           <p className="mt-2 text-sm text-slate-700 text-pretty">登録番号や税率別集計など、基本項目を網羅。※最終確認は各自でお願いします。</p>
         </div>
       </section>
+
+      {ADS_ENABLED && (
+        <section className="max-w-6xl mx-auto px-4 py-8 no-print">
+          {/* デスクトップ用：468×60 */}
+          <AdSlot
+            html={RAKU_468x60}
+            width={468}
+            height={60}
+            className="hidden md:block mx-auto"
+          />
+          {/* モバイル用：234×60 */}
+          <AdSlot
+            html={RAKU_234x60}
+            width={234}
+            height={60}
+            className="md:hidden mx-auto"
+          />
+        </section>
+      )}
 
     </div>
   );

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,1 @@
+export const ADS_ENABLED = process.env.NEXT_PUBLIC_ENABLE_ADS === "1";


### PR DESCRIPTION
…) with env flag

- Add AdSlot component for safe ad HTML rendering
- Add ads constants with Rakuten banner HTML (468x60, 234x60, 380x60)
- Add feature flag (NEXT_PUBLIC_ENABLE_ADS) to control ad display
- Add ads to landing page footer (responsive: 468x60 for desktop, 234x60 for mobile)
- Add 380x60 ad to how-to page bottom
- Add affiliate disclosure text in footer and how-to page
- All ads use no-print class to hide from printed documents